### PR TITLE
Updated pytube installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple script to download all videos in a youtube playlist (720p quality)
 #####**This script needs Python 3.4.1+**
 
 ```bash
-$ pip install pytube
+$ pip3 install pytube
 ```
 
 ### Usage:


### PR DESCRIPTION
Changed `pip install` to `pip3 install` to ensure python3 installation of pytube.
