### PR TITLE
Download videos under 720p

### DIFF
--- a/ytPlaylistDL.py
+++ b/ytPlaylistDL.py
@@ -59,7 +59,8 @@ def downloadVideo(path, vid_url):
         print("Error:", e.reason, "- Skipping Video with url '"+vid_url+"'.")
         return
 
-    video = yt.get('mp4', '720p')
+    # Sorts videos by resolution and picks the highest quality video
+    video = sorted(yt.filter("mp4"), key=lambda video: int(video.resolution[:-1]), reverse=True)[0]
 
     print("downloading",yt.filename+"...")
     try:

--- a/ytPlaylistDL.py
+++ b/ytPlaylistDL.py
@@ -59,8 +59,10 @@ def downloadVideo(path, vid_url):
         print("Error:", e.reason, "- Skipping Video with url '"+vid_url+"'.")
         return
 
-    # Sorts videos by resolution and picks the highest quality video
-    video = sorted(yt.filter("mp4"), key=lambda video: int(video.resolution[:-1]), reverse=True)[0]
+    try:  # Tries to find the video in 720p
+        video = yt.get('mp4', '720p')
+    except Exception:  # Sorts videos by resolution and picks the highest quality video if a 720p video doesn't exist
+        video = sorted(yt.filter("mp4"), key=lambda video: int(video.resolution[:-1]), reverse=True)[0]
 
     print("downloading",yt.filename+"...")
     try:


### PR DESCRIPTION
Tries to download the 720p version of the video, but if that video doesn't exist, it tries to download the largest video it can.

I ran into this problem downloading some of the MIT OpenCourseWare Courses playlists.
